### PR TITLE
[#HTM-64341-183] Bolletta gateway vs. Secure Submit

### DIFF
--- a/_includes/creditcard.md
+++ b/_includes/creditcard.md
@@ -396,7 +396,7 @@ Transaction Id | The authorization transaction Id.
 Amount (optional) | An amount to charge (optional). Used if different from original authorization.
 
 ### Returns: HpsReportTransactionDetails (of HpsAuthorization)
-
+ 
 Parameter | Description
 --------- | -----------
 HpsAuthorization | Returns the above HpsAuthorization data
@@ -421,7 +421,7 @@ creditService.Refund(10.00m, "usd", chargeResponse.TransactionId);
 {% highlight php %}
 <?php
 $response = $chargeService->charge(10, "usd", "put single or multi-use token here", $cardHolder);
-$chargeService->refundTransaction(10, "usd", $response->transactionId);
+$chargeService->refund(10, "usd", $response->transactionId);
 {% endhighlight %}
 
 {% highlight java %}
@@ -478,7 +478,7 @@ creditService.Reverse(authResponse.TransactionId, 10.00m, "usd");
 {% highlight php %}
 <?php
 $response = $chargeService->authorize(10, "usd", "put single or multi-use token here", $cardHolder);
-$chargeService->reverseTransaction($response->transactionId, 10, "usd");
+$chargeService->reverse($response->transactionId, 10, "usd");
 {% endhighlight %}
 
 {% highlight java %}


### PR DESCRIPTION
FYI, your documentation is incorrect here:
https://developer.heartlandpaymentsystems.com/SecureSubmit/Documentation
In the "Refund a transaction" section, it says to do this for PHP:
$chargeService->refundTransaction(10, "usd", $response->transactionId);
But if you look at the available methods in the code:
https://github.com/hps/heartland-php/blob/master/src/Services/Gateway/HpsCreditService.php#L247
The actual method name is "refund" and not "refundTransaction".

During peer review it was noticed that Reverse had the same issue